### PR TITLE
Mention merge tools to resolve conflicts

### DIFF
--- a/02-version-control/02-version-control.Rmd
+++ b/02-version-control/02-version-control.Rmd
@@ -999,6 +999,8 @@ What do these symbols mean?
 ### How merge conflicts are fixed
 
 - Fixing these conflicts is a matter of (manually) editing the README file.
+  - For everyday use, it might be worthwhile to [set up](https://stackoverflow.com/questions/12956509/how-to-set-meld-as-git-mergetool) a [merge-tool](https://stackoverflow.com/questions/137102/whats-the-best-visual-merge-tool-for-git) such as [meld](https://meldmerge.org/).
+
 - Delete the lines of the text that you don't want.
 - Then, delete the special Git merge conflict symbols.
 - Once that's done, you should be able to stage, commit, pull and finally push your changes to the GitHub repo without any errors.


### PR DESCRIPTION
Hi!

I am not sure if opening PRs on this is intended, sorry in advance if that is presumptuous.

Looking through the slide-deck once more, I felt like it would be nice to at least mention these tools. I do not think they require any actual attention during the lecture, but the slide decks are very comprehensive and seem to me like a resource beyond what is actively talked about during class.

My reasoning for this proposal is that, while I totally agree that it is important to know about how bare-bones git handles these conflicts, resolving them without tooling is scary, exhausting and error-prone. This is especially true for larger conflicts that go beyond the scope of only a few lines. I think just knowing that these tools are out there is helpful, as their existence is not obvious.

> [!NOTE]
> I did not include the knitted document in this PR, **but would be happy to do so if you'd like**.
> Reason for not doing so is that things like the output of the local `git` version change as well and I did not want to introduce any unwanted inconsistencies.